### PR TITLE
Update settings.platform.php with new temporary path configuration

### DIFF
--- a/web/sites/default/settings.platformsh.php
+++ b/web/sites/default/settings.platformsh.php
@@ -80,8 +80,8 @@ if ($platformsh->hasRelationship('redis') && !drupal_installation_attempted() &&
 if (!isset($settings['file_private_path'])) {
   $settings['file_private_path'] = $platformsh->appDir . '/private';
 }
-if (!isset($config['system.file']['path']['temporary'])) {
-  $config['system.file']['path']['temporary'] = $platformsh->appDir . '/tmp';
+if (!isset($settings['file_temp_path'])) {
+  $settings['file_temp_path'] = $platformsh->appDir . '/tmp';
 }
 
 // Configure the default PhpStorage and Twig template cache directories.


### PR DESCRIPTION
Looks like the temporary file path setting has changed in settings.php for Drupal 8.8. Here's a patch to fix it.