### PR TITLE
Allow database credentials to be set for local development

### DIFF
--- a/web/sites/default/settings.platformsh.php
+++ b/web/sites/default/settings.platformsh.php
@@ -6,21 +6,23 @@
 
 $platformsh = new \Platformsh\ConfigReader\Config();
 
+if($platformsh->hasRelationship('database')) {
+  // Configure the database.
+  $creds = $platformsh->credentials('database');
+  $databases['default']['default'] = [
+    'driver' => $creds['scheme'],
+    'database' => $creds['path'],
+    'username' => $creds['username'],
+    'password' => $creds['password'],
+    'host' => $creds['host'],
+    'port' => $creds['port'],
+    'pdo' => [PDO::MYSQL_ATTR_COMPRESS => !empty($creds['query']['compression'])]
+  ];
+}
+
 if (!$platformsh->inRuntime()) {
   return;
 }
-
-// Configure the database.
-$creds = $platformsh->credentials('database');
-$databases['default']['default'] = [
-  'driver' => $creds['scheme'],
-  'database' => $creds['path'],
-  'username' => $creds['username'],
-  'password' => $creds['password'],
-  'host' => $creds['host'],
-  'port' => $creds['port'],
-  'pdo' => [PDO::MYSQL_ATTR_COMPRESS => !empty($creds['query']['compression'])]
-];
 
 // Enable Redis caching.
 if ($platformsh->hasRelationship('redis') && !drupal_installation_attempted() && extension_loaded('redis') && class_exists('Drupal\redis\ClientFactory')) {


### PR DESCRIPTION
Currently, the platform database credentials are not being set during local development when following the recommended steps at https://docs.platform.sh/gettingstarted/local-development.html.

This is because `$platformsh->inRuntime` checks for the presence of `PLATFORM_ENVIRONMENT` and returns before it can get to the database config block when the env var is not set.

This change moves the `$platformsh->inRuntime()` check to after the database credentials are set.