### PR TITLE
Check $platformsh->inRuntime() before using platform.sh credentials.

### DIFF
--- a/web/sites/default/settings.platformsh.php
+++ b/web/sites/default/settings.platformsh.php
@@ -8,6 +8,10 @@ use Drupal\Core\Installer\InstallerKernel;
 
 $platformsh = new \Platformsh\ConfigReader\Config();
 
+if (!$platformsh->inRuntime()) {
+  return;
+}
+
 // Configure the database.
 $creds = $platformsh->credentials('database');
 $databases['default']['default'] = [
@@ -19,10 +23,6 @@ $databases['default']['default'] = [
   'port' => $creds['port'],
   'pdo' => [PDO::MYSQL_ATTR_COMPRESS => !empty($creds['query']['compression'])]
 ];
-
-if (!$platformsh->inRuntime()) {
-  return;
-}
 
 // Enable Redis caching.
 if ($platformsh->hasRelationship('redis') && !InstallerKernel::installationAttempted() && extension_loaded('redis') && class_exists('Drupal\redis\ClientFactory')) {


### PR DESCRIPTION
I do not know what is "upstream" for these, but this same issue is present in many of the drupal templates.

I encountered error

```
In Config.php line 235:
                                                                                
   No relationships are defined. Are you sure you are on Platform.sh?  If you'  
   re running on your local system you may need to create a tunnel to access y  
   our environment services.  See https://docs.platform.sh/gettingstarted/loca  
   l/tethered.html
```

in a custom testing pipeline and this proposed change fixes that.