### PR TITLE
file_temp_path is a key in $settings not $config

### DIFF
--- a/web/sites/default/settings.platformsh.php
+++ b/web/sites/default/settings.platformsh.php
@@ -82,8 +82,8 @@ if ($platformsh->hasRelationship('redis') && !InstallerKernel::installationAttem
 if (!isset($settings['file_private_path'])) {
   $settings['file_private_path'] = $platformsh->appDir . '/private';
 }
-if (!isset($config['file_temp_path'])) {
-  $config['file_temp_path'] = $platformsh->appDir . '/tmp';
+if (!isset($settings['file_temp_path'])) {
+  $settings['file_temp_path'] = $platformsh->appDir . '/tmp';
 }
 
 // Configure the default PhpStorage and Twig template cache directories.


### PR DESCRIPTION
According to https://www.drupal.org/project/drupal/releases/8.8.0 the correct setting is now:
`$settings['file_temp_path'] = '/path/to/your/temporary/folder';`
while previously it was 
`$config['system.file']['path']['temporary'] = 'my/temp/dir';`